### PR TITLE
Use updated graphviz API for better viewing and rendering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setuptools.setup(
 	packages = setuptools.find_packages(where="src"),
 	python_requires = ">=3.6",
 	install_requires = [
-		"graphviz<0.16", "IPython"
+		"IPython", "graphviz"
 	]
 )

--- a/src/pyfoma/__init__.py
+++ b/src/pyfoma/__init__.py
@@ -16,6 +16,8 @@ __email__      = "mans.hulden@gmail.com"
 __status__     = "Prototype"
 
 
+# This project is (partially) documented using the Sphinx docstring convention
+
 # Dynamically add the algorithms contained in `algorithms.py` to the FST as instance methods
 # Is this hacky? Yes, but it means we can keep our algorithm logic in the `algorithms` module,
 # while still being able to call useful methods like `determinize` on the actual FST instances

--- a/src/pyfoma/fst.py
+++ b/src/pyfoma/fst.py
@@ -220,15 +220,17 @@ class FST:
             self.alphabet &= seen
         return self
 
-    def view(self, raw=False, show_weights=False, show_alphabet=True):
-        """Graphviz viewing and display in Jupyter.
-           Keyword arguments:
-           raw -- if True, show label tuples and weights unformatted
-           show_weights -- force display of weights even if 0.0
-           show_alphabet -- displays the alphabet below the FST
+    def view(self, raw=False, show_weights=False, show_alphabet=True) -> 'graphviz.Digraph':
+        """Creates a 'graphviz.Digraph' object to view the FST. Will automatically display the FST in Jupyter.
+
+            :param raw: if True, show label tuples and weights unformatted
+            :param show_weights: force display of weights even if 0.0
+            :param show_alphabet: displays the alphabet below the FST
+            :return: A Digraph object which will automatically display in Jupyter.
+
+           If you would like to display the FST from a non-Jupyter environment, please use :code:`FST.render`
         """
         import graphviz
-        from IPython.display import display
         def _float_format(num):
             if not show_weights:
                 return ""
@@ -282,6 +284,16 @@ class FST:
                     targetlabel = str(statenums[id(target)])
                 g.edge(sourcelabel, targetlabel, label=graphviz.nohtml(printlabel))
         return g
+
+    def render(self, view=True, filename: str='FST', format='pdf'):
+        """
+        Renders the FST to a file and optionally opens the file.
+        :param view: If True, the rendered file will be opened.
+        :param format: The file format for the Digraph. Typically 'pdf', 'png', or 'svg'. View all formats: https://graphviz.org/docs/outputs/
+        """
+        digraph = self.view()
+        digraph.format = format
+        digraph.render(view=view, filename=filename, cleanup=True)
 
     def all_transitions(self, states):
         """Enumerate all transitions (state, label, Transition) for an iterable of states."""

--- a/src/pyfoma/fst.py
+++ b/src/pyfoma/fst.py
@@ -281,7 +281,7 @@ class FST:
                 else:
                     targetlabel = str(statenums[id(target)])
                 g.edge(sourcelabel, targetlabel, label=graphviz.nohtml(printlabel))
-        display(graphviz.Source(g))
+        return g
 
     def all_transitions(self, states):
         """Enumerate all transitions (state, label, Transition) for an iterable of states."""


### PR DESCRIPTION
Graphviz updated their API so that `Digraph` objects can now be rendered in Jupyter directly. Thus, the `view()` method now can just return the Digraph directly, and Jupyter will display it as before.

Additionally, I added the `render` method for rendering and viewing in environments other than Jupyter. The method saves the FST to a file (pdf by default) and opens it. 