### PR TITLE
fix: remove "size" attribute from view()

### DIFF
--- a/src/pyfoma/fst.py
+++ b/src/pyfoma/fst.py
@@ -252,7 +252,7 @@ class FST:
                     any(s.finalweight != 0.0 for s in self.finalstates):
                 show_weights = True
 
-        g.attr(rankdir='LR', size='8,5')
+        g.attr(rankdir='LR')
         g.attr('node', shape='doublecircle', style='filled')
         for s in self.finalstates:
             g.node(str(statenums[id(s)]) + _float_format(s.finalweight))


### PR DESCRIPTION
In most cases this size attribute is much too small and results in the FST being cut off at the right and bottom, often drastically so, when viewed in Jupyter.  If we simply do not set "size" then it might not fit in the cell but at least we get scroll bars.  Also the user can set "size" after the fact, e.g.:

    dg = fst.view()
    dg.attr(size, "42,14")
    dg

but it is less obvious how to *remove* the size (I think it can be done with `del dg.graph_attr["size"]`)