### PR TITLE
Flag merge

### DIFF
--- a/src/pyfoma/eliminate_flags.py
+++ b/src/pyfoma/eliminate_flags.py
@@ -1,0 +1,128 @@
+from itertools import product
+from functools import reduce
+import re
+
+from pyfoma.fst import FST
+from pyfoma.flag import FlagOp
+
+EMPTYVAL="{}"
+
+def set_pos(X, y):
+    """ Set variable X to value y (i.e. [[$X=y]] | [[$X?=y]]). """
+    return FST.re(f"('[[${X}={y}]]' | '[[${X}?={y}]]')")
+
+def set_any(X, ys):
+    """ Set variable X to any value in ys. """
+    res = [set_pos(X,y) for y in ys]
+    return reduce(lambda x,y: FST.re("$x | $y", {"x":x, "y":y}), res)
+
+def set_neg(X, y, ys):
+    """ Set variable X to any value in ys except y. """
+    return FST.re("$any - $set", {"any":set_any(X, ys), "set":set_pos(X, y)})
+
+def value_restr(X, y, ys, pos):
+    """ Return minimal condition for [[$X==y]] (and [[$X?=y]]) or [[$X!=y]] to fail. 
+        Precondition: y != "{}". """
+    op = f"('[[${X}=={y}]]'|'[[${X}?={y}]]')" if pos else f"'[[${X}!={y}]]'"
+    setval = set_neg(X,y,ys) if pos else set_pos(X,y)
+    return FST.re(f".* $set (. - $any)* {op} .*", {"set":setval, "any":set_any(X,ys)})
+
+def empty_restr(X, y, ys, pos):
+    """ Return minimal condition for [[$X=={}]] (and [[$X?={}]]) or [[$X!={}]] to fail. """
+    op = f"('[[${X}=={y}]]'|'[[${X}?={y}]]')" if pos else f"'[[${X}!={y}]]'"
+    return FST.re(f"(. - $any)* {op} .*", {"any":set_any(X,ys)})
+
+def eq_restr(X1, X2, y1, y2, ys):
+    """ Return minimal condition for [[$X1==$X2]] or [[$X1!=$X2]] to fail given 
+        values y1 and y2 (and y1 != "{}"). """
+    set1 = FST.re(".* $set (. - $any)*", {"set":set_pos(X1,y1), "any":set_any(X1, ys)})
+    set2 = FST.re(".* $set (. - $any)*", {"set":set_pos(X2,y2), "any":set_any(X2, ys)})
+    op = f"'[[${X1}!=${X2}]]'" if y1 == y2 else f"'[[${X1}==${X2}]]'"
+    return FST.re(f"($set1 & $set2) {op} .*", {"set1": set1, "set2": set2})
+
+def empty_eq_restr(X1, X2, ys):
+    """ Return minimal condition for [[$X1==$X2]] or [[$X1!=$X2]] to fail given 
+        values that the value of X1 is "{}". """
+    set1 = FST.re("(. - $any)*", {"any":set_any(X1,ys)})
+    set2 = FST.re(".* $set (. - $any)*", 
+                  {"set":set_neg(X2,EMPTYVAL,ys), "any":set_any(X2, ys)})
+    return FST.re("($set1 & $set2) '[[${X1}==${X2}]]' .*", {"set1":set1, "set2":set2})
+
+def get_value_tests(Xs, ys):
+    """ Return a list of tests for [[$X==y]], [[$X?=y]] and [[$X!=y]] flags which 
+        valid strings have to pass. """
+    tests = []  
+    for X in Xs:
+        for y in ys:
+            tests.append(value_restr(X, y, ys, pos=True))
+            tests.append(value_restr(X, y, ys, pos=False))
+            if y == EMPTYVAL:
+                tests.append(empty_restr(X, y, ys, pos=False))
+            else:
+                tests.append(empty_restr(X, y, ys, pos=True))
+    return [FST.re(".* - $r", {"r":r}) for r in tests]
+
+def get_eq_tests(Xs, ys):
+    """ Return a list of tests for [[$X==$Y]], [[$X!=$Y]] flags which valid strings 
+        have to pass. """
+    tests = []
+    for X1, X2 in product(Xs, repeat=2):
+        if X1 != X2:
+            for y1, y2 in product(ys, ys):
+                tests.append(eq_restr(X1, X2, y1, y2, ys))
+            tests.append(empty_eq_restr(X1, X2, ys))
+    return [FST.re(".* - $r", {"r":r}) for r in tests]
+
+def eliminate_flags(fst, Xs=None):
+    """Eliminate all flag diacritics from an FST. 
+
+    :param fst: An FST.
+    :param Xs: The variables to be eliminated. If None, then all
+    variables will be eliminated.
+
+    :return: An FST without flag diacritics with equivalent behavior
+    to 'fst'
+    """
+    if Xs == None:
+        flags = [FlagOp(sym) for sym in fst.alphabet if FlagOp.is_flag(sym)]
+        Xs = set(flag.var for flag in flags)
+        ys = set(flag.val for flag in flags)
+    if len(Xs) == 0:
+        return fst
+    tests = get_value_tests(Xs, ys) + get_eq_tests(Xs, ys)
+    flag_filter = reduce(lambda x, y: FST.re("$x & $y",{"x":x, "y":y}),tests)
+    flags = [sym for sym in fst.alphabet if FlagOp.is_flag(sym)]
+    clean = reduce(lambda x, y: FST.re("$x @ $y",{"x":x, "y":y}), 
+                   [FST.re(f"$^rewrite('{flag}':'')") for flag in flags])
+    fst = FST.re("$^invert($fst @ $filter @ $clean)", 
+                 {"fst":fst, "filter":flag_filter, "clean":clean})
+    fst = FST.re("$^invert($fst @ $clean)", {"fst":fst, "clean":clean})
+    return fst
+
+################################
+#                              #
+#            TESTS             #
+#                              #
+################################
+import unittest
+
+class TestValueFlags(unittest.TestCase):
+    def test_neg(self):
+        fst = FST.re("a")
+        fst = eliminate_flags(fst)
+        self.assertTrue(fst == FST.re("a"))
+        fst = FST.re("a '[[$X==x]]' b")
+        fst = eliminate_flags(fst)
+        self.assertEqual(fst, FST.re("a b"))
+        
+if __name__=="__main__":
+    Grammar = {}
+    Grammar["S"] = [("","A")]
+    Grammar["A"] = [("a'[[$X=a]]'", "B"), ("b'[[$X=b]]'", "B"), ("c", "B")]
+    Grammar["B"] = [("a'[[$X==a]]'", "C"), ("b'[[$X==b]]'", "C")]
+    Grammar["C"] = [("a'[[$Y=a]]'", "D"), ("b'[[$Y=b]]'", "D")]
+    Grammar["D"] = [("'[[$Y==$X]]'", "#")]
+    Lexicon = FST.rlg(Grammar, "S").epsilon_remove().minimize()
+    Lexicon = eliminate_flags(Lexicon, "X Y".split(), "a b {}".split())
+    print(Lexicon)
+    unittest.main()

--- a/src/pyfoma/flag.py
+++ b/src/pyfoma/flag.py
@@ -1,0 +1,360 @@
+import re
+from typing import Dict, Set, Sequence
+
+# Empty variable value.
+EMPTY="{}"
+
+# Defines a valid flag diacritic
+FLAGRE=r"\[\[(\$\w+)([?!=]?=)(\$?\w+|{})\]\]"
+
+class FlagOp:
+    def __init__(self, sym: str):
+        """Creates a Flag diacritic
+
+        :param sym: String representation of flag diacritic 
+
+        The parameter 'sym' should follow the format [[XYZ]], for
+        example "[[$Num=Sg]]", where:
+
+        1. X is a variable name matching the regex "[$]\w+" 
+        2. Y is one of the operators "=" (set value), "==" (check that
+        value equals), "!=" (check that value does not equal) or "$="
+        (unify to value) 
+        3. Z is a value matching the regex "[$]?\w+". If the value
+        starts with $, then it refers to a variable.
+
+        More formally, any flag diacritic needs to match the
+        expression flag.FLAGRE.
+
+        """
+
+        match = re.match(FLAGRE,sym)
+        self.var, self.op, self.val = match.group(1,2,3)
+        self.eq_flag = (self.val[0] == "$")
+        self.op_func = {"=":self.setv,
+                        "==":self.check,
+                        "!=":self.neg_check,
+                        "?=":self.unify}[self.op]
+
+    @staticmethod
+    def is_flag(sym: str) -> bool:
+        """Check that 'sym' matches the format required by FlagOp.__init__
+
+        :param sym: A string
+
+        :return: True is 'sym' is a valig flag diacritic. False,
+        otherwise.
+
+        """
+        return re.match(FLAGRE,sym) != None
+    
+    def setv(self, config: Dict[str, str], val: str) -> bool:
+        """ The operator "=" """
+        config[self.var] = val
+        return True
+
+    def check(self, config: Dict[str, str], val: str) -> bool:
+        """ The operator "==" """
+        return config[self.var] == val
+
+    def neg_check(self, config: Dict[str, str], val: str) -> bool:
+        """ The operator "!=" """
+        return config[self.var] != val
+
+    def unify(self, config: Dict[str, str], val: str) -> bool:
+        """ The operator "?=" """
+        if config[self.var] in [EMPTY, val]:
+            config[self.var] = val
+            return True
+        return False
+
+    def __call__(self, config: Dict[str, str]) -> bool:
+        """Perform test/operation specified by this flag 
+
+        :param config: A dictionary of variable:value pairs
+        (e.g. {"$var1":"val", "var2":"{}"})
+
+        :return: True if test/operation succeeds. False, otherwise.
+
+        The state of 'config' will change to reflect the operation
+        specified by this flag (when the operator is "=" or "?=").
+        """
+        val = config[self.val] if self.eq_flag else self.val
+        # TODO: Implementing this as a separate function call can be
+        # slow. If it becomes an issue, then optimize.
+        return self.op_func(config, val)        
+        
+class FlagFilter:
+    def __init__(self, alphabet: Set[str]):
+        """ Create FlagFilter from an FST alphabet
+        
+        :param alphabet: A symbol set (containing strings)
+        """ 
+        self.alphabet = {sym for sym in alphabet}
+        self.flags = {sym:FlagOp(sym) for sym in alphabet
+                      if FlagOp.is_flag(sym)}
+        self.vars = {flag.var for flag in self.flags.values()}
+        
+class FlagStreamFilter(FlagFilter):
+    def __init__(self, alphabet: Set[str]):
+        """ Create FlagStreamFilter from an FST alphabet
+        
+        :param alphabet: A symbol set (containing strings)
+        """
+        super().__init__(alphabet)
+        self.reset()
+
+    def reset(self):
+        """ Reset all variables to empty value "{}" """
+        self.config = {var:EMPTY for var in self.vars}
+        self.has_failed = False
+        
+    def check(self, sym: str) -> bool:
+        """Read next symbol and check fla diacritic configuration
+
+        :param sym: A symbol in self.alphabet
+        
+        :return: True if the combination of flag diactritics upto this
+        point is valid. False, otherwise.
+
+        Raises KeyError when 'sym' is missing from the FST alphabet.
+        """
+        if sym != "" and not sym in self.alphabet:
+            raise KeyError(sym)
+        if sym in self.flags and not self.flags[sym](self.config):
+            self.has_failed = True
+        return not self.has_failed
+
+# FlagStringFilter could be implemented on top of FlagStreamFilter but
+# this custom implementation is roughly twice as fast due to fewer
+# function calls.
+class FlagStringFilter(FlagFilter):
+    def __call__(self, seq: Sequence[str]) -> bool:
+        """Check that flag diacritic configuration is valid
+
+        :param seq: A list of string symbols in self.alphabet
+        
+        :return: True if the combination of flag diactritics in
+        'seq' is valid. False, otherwise.
+
+        Raises KeyError when 'seq' contains symbols which are
+        absent from the FST alphabet.
+        """
+        config = {var:EMPTY for var in self.vars}
+        for sym in seq:
+            if sym != "" and not sym in self.alphabet:
+                raise KeyError(sym)
+            if sym in self.flags and not self.flags[sym](config):
+                return False
+        return True
+
+####################################
+###                              ###
+###            TESTS             ###
+###                              ###
+####################################
+
+import unittest
+import time
+
+class TestFlagOp(unittest.TestCase):
+    def test_init(self):
+        for op in "?= == != =".split():
+            for val in "val {}".split():
+                fo = FlagOp(f"[[$var{op}{val}]]")
+                self.assertEqual(fo.var, "$var")
+                self.assertEqual(fo.op, op)
+                self.assertEqual(fo.val, val)
+
+    def test_is_flag(self):
+        self.assertFalse(FlagOp.is_flag(""))
+        for op in "?= == != =".split():
+            self.assertFalse(FlagOp.is_flag("[$var{op}val]"))
+            self.assertFalse(FlagOp.is_flag("[[var{op}val]]"))
+        self.assertFalse(FlagOp.is_flag("[[$var]]"))
+
+        for op in "?= == != =".split():
+            for val in "val {} $var2".split():
+                self.assertTrue(FlagOp.is_flag(f"[[$var1{op}{val}]]"))
+
+    def test_init_non_flag(self):
+        self.assertRaises(AttributeError, FlagOp, sym="")
+        for op in "?= == != =".split():
+            self.assertRaises(AttributeError, FlagOp, sym=f"[$var{op}val]")
+            self.assertRaises(AttributeError, FlagOp, sym=f"[[var{op}val]]")
+        self.assertRaises(AttributeError, FlagOp, sym="[[$var]]")
+
+    def test_call(self):
+        for val in "{} foo".split():
+            config = {"$var1":val}
+            pos_op_val = FlagOp(f"[[$var1=={val}]]")
+            neg_op_val = FlagOp(f"[[$var1!={val}]]")
+            pos_op_oval = FlagOp(f"[[$var1==bar]]")
+            neg_op_oval = FlagOp(f"[[$var1!=bar]]")
+            self.assertTrue(pos_op_val(config))
+            self.assertFalse(neg_op_val(config))
+            self.assertFalse(pos_op_oval(config))
+            self.assertTrue(neg_op_oval(config))
+            self.assertEqual(config, {"$var1":val})
+            
+        for val in "{} foo".split():
+            config = {"$var1":"{}"}
+            set_op = FlagOp(f"[[$var1={val}]]")
+            self.assertTrue(set_op(config))
+            self.assertEqual(config, {"$var1":val})
+
+            config = {"$var1":"bar"}
+            set_op = FlagOp(f"[[$var1={val}]]")
+            self.assertTrue(set_op(config))
+            self.assertEqual(config, {"$var1":val})
+
+            config = {"$var1":"{}"}
+            unify_op = FlagOp(f"[[$var1?={val}]]")
+            self.assertTrue(unify_op(config))
+            self.assertEqual(config, {"$var1":val})
+
+            config = {"$var1":val}
+            unify_op = FlagOp(f"[[$var1?={val}]]")
+            self.assertTrue(unify_op(config))
+            self.assertEqual(config, {"$var1":val})
+
+            config = {"$var1":"bar"}
+            unify_op = FlagOp(f"[[$var1?={val}]]")
+            self.assertFalse(unify_op(config))
+
+            config = {"$var1":"foo", "$var2":"foo"}
+            pos_op = FlagOp("[[$var1==$var2]]")
+            neg_op = FlagOp("[[$var1!=$var2]]")
+            self.assertTrue(pos_op(config))
+            self.assertFalse(neg_op(config))
+            
+            for val2 in "bar {}":
+                config = {"$var1":"foo", "$var2":val2}
+                self.assertFalse(pos_op(config))            
+                self.assertTrue(neg_op(config))
+
+            config = {"$var1":"foo", "$var2":"bar"}
+            set_op = FlagOp("[[$var1=$var2]]")
+            self.assertTrue(set_op(config))
+            self.assertEqual(config["$var1"], "bar")
+            self.assertEqual(config["$var2"], "bar")
+
+            config = {"$var1":"foo", "$var2":"bar"}
+            unify_op = FlagOp("[[$var1?=$var2]]")
+            self.assertFalse(unify_op(config))
+            
+            config = {"$var1":"foo", "$var2":"{}"}
+            unify_op = FlagOp("[[$var1?=$var2]]")
+            self.assertFalse(unify_op(config))
+
+            config = {"$var1":"{}", "$var2":"foo"}
+            unify_op = FlagOp("[[$var1?=$var2]]")
+            self.assertTrue(unify_op(config))
+            self.assertEqual(config["$var1"], "foo")
+            self.assertEqual(config["$var2"], "foo")
+
+            config = {"$var1":"foo", "$var2":"foo"}
+            unify_op = FlagOp("[[$var1?=$var2]]")
+            self.assertTrue(unify_op(config))
+            self.assertEqual(config["$var1"], "foo")
+            self.assertEqual(config["$var2"], "foo")
+            
+class TestFlagFilter(unittest.TestCase):
+    def test_init(self):
+        flags = {f"[[{var}{op}{val}]]"
+                 for var in "$var1 $var2".split()
+                 for op in "= == != ?=".split()
+                 for val in "foo bar {} $var1 $var2".split()}
+        ffilter = FlagFilter(flags.union({"a"}))
+        self.assertEqual(set(ffilter.flags.keys()), flags)
+
+    def test_strings_pos(self):
+        flags = {f"[[{var}{op}{val}]]"
+                 for var in "$var1 $var2".split()
+                 for op in "= == != ?=".split()
+                 for val in "foo bar {} $var1 $var2".split()}
+        ffilter = FlagStringFilter(flags.union({"a","b"}))
+        self.assertTrue(ffilter(""))
+        self.assertTrue(ffilter("a"))
+        self.assertTrue(ffilter("[[$var1=foo]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]]".split()))
+        self.assertTrue(ffilter("a [[$var1={}]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] b".split()))
+        self.assertTrue(ffilter("a [[$var1?=foo]] b".split()))
+        self.assertTrue(ffilter("a [[$var1!=foo]] b".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var1==foo]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var1?=foo]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var1!=bar]]".split()))
+        self.assertTrue(ffilter("a [[$var1?=foo]] [[$var1==foo]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var1={}]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var1={}]] [[$var1=={}]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var1={}]] [[$var1!=foo]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var1={}]] [[$var1?=bar]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var2=$var1]] [[$var2!={}]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var2=$var1]] [[$var2==foo]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var2?=$var1]] [[$var2!={}]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var2?=$var1]] [[$var2==foo]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var2=foo]] [[$var1==$var2]]".split()))
+        self.assertTrue(ffilter("a [[$var1=foo]] [[$var2=bar]] [[$var1!=$var2]]".split()))
+        
+    def test_strings_neg(self):
+        flags = {f"[[{var}{op}{val}]]"
+                 for var in "$var1 $var2".split()
+                 for op in "= == != ?=".split()
+                 for val in "foo bar {} $var1 $var2".split()}
+        ffilter = FlagStringFilter(flags.union({"a","b"}))
+        self.assertFalse(ffilter("a [[$var1==foo]] b".split()))
+        self.assertFalse(ffilter("a [[$var1=foo]] [[$var1!=foo]]".split()))
+        self.assertFalse(ffilter("a [[$var1=foo]] [[$var1=={}]]".split()))
+        self.assertFalse(ffilter("a [[$var1=foo]] [[$var1?=bar]]".split()))
+        self.assertFalse(ffilter("a [[$var1=foo]] [[$var1?=$var2]]".split()))
+        self.assertFalse(ffilter("a [[$var1=foo]] [[$var2=bar]] [[$var1?=$var2]]".split()))
+        self.assertFalse(ffilter("a [[$var1=foo]] [[$var2=bar]] [[$var1==bar]]".split()))
+        self.assertFalse(ffilter("a [[$var1=foo]] [[$var2=bar]] [[$var1==$var2]]".split()))
+        self.assertFalse(ffilter("a [[$var1=foo]] [[$var2=$var1]] [[$var1!=$var2]]".split()))
+
+    def test_stream(self):
+        flags = {f"[[{var}{op}{val}]]"
+                 for var in "$var1 $var2".split()
+                 for op in "= == != ?=".split()
+                 for val in "foo bar {} $var1 $var2".split()}
+        ffilter = FlagStreamFilter(flags.union({"a","b"}))
+        for i,sym in enumerate("a [[$var1=foo]] [[$var2=$var1]] [[$var1!=$var2]]".split()):
+            if i == 3:
+                self.assertFalse(ffilter.check(sym))
+            else:
+                self.assertTrue(ffilter.check(sym))
+        self.assertTrue(ffilter.has_failed)
+
+        ffilter.reset()
+        for sym in "a [[$var1=foo]] [[$var2=$var1]] [[$var1==$var2]]".split():
+            ffilter.check(sym)
+        self.assertFalse(ffilter.has_failed)
+        
+def time_flag_execution(trials):
+    flags = {f"[[{var}{op}{val}]]"
+             for var in "$var1 $var2".split()
+             for op in "= == != ?=".split()
+             for val in "foo bar {} $var1 $var2".split()}
+    ffilter = FlagStringFilter(flags.union({"a","b"}))
+
+    seq_a = ["a" for i in range(10)]
+    seq_set = ["[[$var1=foo]]"]
+    seq_check_pos = ["[[$var1==foo]]"]
+    seq_check_neg = ["[[$var1!=foo]]"]
+    seq_unify = ["[[$var1?=$var2]]"]
+
+    for ex in [seq_a, seq_set, seq_check_pos, seq_check_neg, seq_unify]:
+        start = time.time_ns()
+        for i in range(trials):
+            ffilter(seq_a)
+        stop = time.time_ns()
+        print(f"Processed {trials} {ex} examples in {(stop-start)/10**6}ms")
+    
+if __name__=="__main__":
+    ### Test main ###
+    print("Run performance tests")
+    time_flag_execution(1000000)
+    print()
+    print("Run unit tests")
+    unittest.main()

--- a/src/pyfoma/fst.py
+++ b/src/pyfoma/fst.py
@@ -369,11 +369,11 @@ class FST:
 
     def generate(self: 'FST', word, weights=False, tokenize_outputs=False, obey_flags=False):
         """Pass word through FST and return generator that yields all outputs."""
-        yield from self.apply(word, inverse=False, weights=weights, tokenize_outputs=tokenize_outputs, obey_flags)
+        yield from self.apply(word, inverse=False, weights=weights, tokenize_outputs=tokenize_outputs, obey_flags=obey_flags)
 
     def analyze(self: 'FST', word, weights=False, tokenize_outputs=False, obey_flags=False):
         """Pass word through FST and return generator that yields all inputs."""
-        yield from self.apply(word, inverse=True, weights=weights, tokenize_outputs=tokenize_outputs, obey_flags)
+        yield from self.apply(word, inverse=True, weights=weights, tokenize_outputs=tokenize_outputs, obey_flags=obey_flags)
 
     def apply(self: 'FST', word, inverse=False, weights=False, tokenize_outputs=False, obey_flags=False):
         """Pass word through FST and return generator that yields outputs.

--- a/src/pyfoma/fst.py
+++ b/src/pyfoma/fst.py
@@ -369,11 +369,11 @@ class FST:
 
     def generate(self: 'FST', word, weights=False, tokenize_outputs=False, obey_flags=False):
         """Pass word through FST and return generator that yields all outputs."""
-        yield from self.apply(word, inverse=False, weights=weights, tokenize_outputs=tokenize_outputs)
+        yield from self.apply(word, inverse=False, weights=weights, tokenize_outputs=tokenize_outputs, obey_flags)
 
     def analyze(self: 'FST', word, weights=False, tokenize_outputs=False, obey_flags=False):
         """Pass word through FST and return generator that yields all inputs."""
-        yield from self.apply(word, inverse=True, weights=weights, tokenize_outputs=tokenize_outputs)
+        yield from self.apply(word, inverse=True, weights=weights, tokenize_outputs=tokenize_outputs, obey_flags)
 
     def apply(self: 'FST', word, inverse=False, weights=False, tokenize_outputs=False, obey_flags=True):
         """Pass word through FST and return generator that yields outputs.

--- a/src/pyfoma/fst.py
+++ b/src/pyfoma/fst.py
@@ -375,7 +375,7 @@ class FST:
         """Pass word through FST and return generator that yields all inputs."""
         yield from self.apply(word, inverse=True, weights=weights, tokenize_outputs=tokenize_outputs, obey_flags)
 
-    def apply(self: 'FST', word, inverse=False, weights=False, tokenize_outputs=False, obey_flags=True):
+    def apply(self: 'FST', word, inverse=False, weights=False, tokenize_outputs=False, obey_flags=False):
         """Pass word through FST and return generator that yields outputs.
            if inverse == True, map from range to domain.
            weights is by default False. To see the cost, set weights to True.

--- a/src/pyfoma/fst.py
+++ b/src/pyfoma/fst.py
@@ -5,6 +5,7 @@
 import heapq, operator, itertools, re as pyre, functools
 from collections import deque, defaultdict
 from typing import Callable, Dict, Any
+from pyfoma.flag import FlagStringFilter, FlagOp
 import subprocess
 
 def re(*args, **kwargs):
@@ -365,26 +366,33 @@ class FST:
 
         return newfst, q1q2
 
-    def generate(self: 'FST', word, weights=False, tokenize_outputs=False):
+
+    def generate(self: 'FST', word, weights=False, tokenize_outputs=False, obey_flags=False):
         """Pass word through FST and return generator that yields all outputs."""
         yield from self.apply(word, inverse=False, weights=weights, tokenize_outputs=tokenize_outputs)
 
-    def analyze(self: 'FST', word, weights=False, tokenize_outputs=False):
+    def analyze(self: 'FST', word, weights=False, tokenize_outputs=False, obey_flags=False):
         """Pass word through FST and return generator that yields all inputs."""
         yield from self.apply(word, inverse=True, weights=weights, tokenize_outputs=tokenize_outputs)
 
-    def apply(self: 'FST', word, inverse=False, weights=False, tokenize_outputs=False):
+    def apply(self: 'FST', word, inverse=False, weights=False, tokenize_outputs=False, obey_flags=True):
         """Pass word through FST and return generator that yields outputs.
            if inverse == True, map from range to domain.
-           weights is by default False. To see the cost, set weights to True."""
+           weights is by default False. To see the cost, set weights to True.
+           obey_flags toggles whether invalid flag diacritic
+           combinations are filtered out. By default, flags are
+           treated as epsilons in the input."""
         IN, OUT = [-1, 0] if inverse else [0, -1]  # Tuple positions for input, output
         cntr = itertools.count()
         w = self.tokenize_against_alphabet(word)
         Q, output = [], []
         heapq.heappush(Q, (0.0, 0, next(cntr), [], self.initialstate))  # (cost, -pos, output, state)
+        flag_filter = FlagStringFilter(self.alphabet) if obey_flags else None
+        
         while Q:
             cost, negpos, _, output, state = heapq.heappop(Q)
-            if state == None and -negpos == len(w):
+
+            if state == None and -negpos == len(w) and (not obey_flags or flag_filter(output)):
                 yield_output = ''.join(output) if not tokenize_outputs else output
                 if weights == False:
                     yield yield_output
@@ -394,7 +402,7 @@ class FST:
                 if state in self.finalstates:
                     heapq.heappush(Q, (cost + state.finalweight, negpos, next(cntr), output, None))
                 for lbl, t in state.all_transitions():
-                    if lbl[IN] == '':
+                    if lbl[IN] == '' or FlagOp.is_flag(lbl[IN]):
                         heapq.heappush(Q, (cost + t.weight, negpos, next(cntr), output + [lbl[OUT]], t.targetstate))
                     elif -negpos < len(w):
                         nextsym = w[-negpos] if w[-negpos] in self.alphabet else '.'


### PR DESCRIPTION
Support for flag diacritics. Four flag diacritic operators are provided:

* `[[$VAR=VAL]]` sets variable `$VAR` to value `VAL`
* `[[$VAR?=VAL]]` unifies variable `$VAR` with value `VAL`
* `[[$VAR==VAL]]` checks that the value of variable `$VAR` equals `VAL`
* `[[$VAR!=VAL]]` checks that the value of variable `$VAR` does not equal `VAL`

The function `eliminate_flags` in eliminate_flags.py takes an FST with flag diacritics as input and returns an equivalent FST without flag diacritics.

The functions `analyze`, `generate` and `apply` in fst.py optionally check and apply flag diacritics. This behaviour is toggled by the argument `obey_flags.`