### PR TITLE
Enable ~ operator for complement

### DIFF
--- a/src/pyfoma/algorithms.py
+++ b/src/pyfoma/algorithms.py
@@ -737,6 +737,11 @@ def difference(fst1: 'FST', fst2: 'FST') -> 'FST':
                        oplus = lambda x,y: x, pathfollow = lambda x,y: x)
 
 
+def complement(fsm: 'FST') -> 'FST':
+    """Returns the complement of an FSM."""
+    return FST.re(".* - $X", {"X": fsm})
+
+
 @_harmonize_alphabet
 def product(fst1: 'FST', fst2: 'FST', finalf = any, oplus = min, pathfollow = lambda x,y: x|y) -> 'FST':
     """Generates the product FST from fst1, fst2. The helper functions by default
@@ -805,5 +810,6 @@ _algorithms_to_add: Dict[str, Callable] = {
     'union': union,
     'intersection': intersection,
     'difference': difference,
-    'product': product
+    'product': product,
+    'complement': complement,
 }

--- a/src/pyfoma/private/regexparse.py
+++ b/src/pyfoma/private/regexparse.py
@@ -30,7 +30,7 @@ class RegexParse:
                 'input': _builtins_input_lambda,
                 'output': _builtins_output_lambda}
     precedence = {"FUNC": 11, "COMMA": 1, "PARAM": 1, "COMPOSE": 3, "UNION": 5, "INTERSECTION": 5,
-                  "MINUS": 5, "CONCAT": 6, "STAR": 9, "PLUS": 9, "OPTIONAL": 9, "WEIGHT": 9,
+                  "MINUS": 5, "CONCAT": 6, "COMPLEMENT": 7, "STAR": 9, "PLUS": 9, "OPTIONAL": 9, "WEIGHT": 9,
                   "CP": 10, "CPOPTIONAL": 10, "RANGE": 9, "CONTEXT": 1, "PAIRUP": 2}
     operands = {"SYMBOL", "VARIABLE", "ANY", "EPSILON", "CHAR_CLASS"}
     operators = set(precedence.keys())
@@ -194,6 +194,8 @@ class RegexParse:
             elif op == 'CHAR_CLASS':
                 charranges, negated = self.character_class_parse(value)
                 _append(stack, FST.character_ranges(charranges, complement=negated))
+            elif op == 'COMPLEMENT':
+                _append(stack, _pop(stack).complement())
         if len(stack) != 1:  # If there's still stuff on the stack, that's a syntax error
             self._error_report(SyntaxError, \
                                "Something's happening here, and what it is ain't exactly clear...", 1, 0)
@@ -208,7 +210,7 @@ class RegexParse:
             (r", *", 'PARAM', r"\w+ *= *[+-]? *\w+", r""),  # Parameter
             (r"'", 'QUOTED', r"(\\[']|[^'])*", r"'"),  # Quoted sym
             (r"", 'SKIPWS', r"[ \t]+", r""),  # Skip ws
-            (r"", 'SHORTOP', r"(:\?|[|\-&*+()?:@,/_])", r""),  # main ops
+            (r"", 'SHORTOP', r"(:\?|[|\-&*+()?:@,/_~])", r""),  # main ops
             (r"\$\^", 'FUNC', r"\w+", r"(?=\s*\()"),  # Functions
             (r"\$", 'VARIABLE', r"\w+", r""),  # Variables
             (r"<", 'WEIGHT', r"[+-]?[0-9]*(\.[0-9]+)?", r">"),  # Weight

--- a/test_pyfoma.py
+++ b/test_pyfoma.py
@@ -70,6 +70,23 @@ class TestFST(unittest.TestCase):
         f2 = FST.regex(r"'[NO\'UN]' '[VERB]'")
         self.assertEqual(f2.alphabet, {"[NO'UN]", "[VERB]"})
 
+    def test_complement(self):
+        f1 = FST.regex("~a")
+        self.assertEqual(0, len(list(f1.generate("a"))))
+        f1 = FST.regex("~(cat | dog)")
+        self.assertEqual(0, len(list(f1.generate("cat"))))
+        self.assertEqual(0, len(list(f1.generate("dog"))))
+        self.assertEqual(1, len(list(f1.generate("octopus"))))
+        f1 = FST.regex("~(cat | dog)s")
+        self.assertEqual(0, len(list(f1.generate("cats"))))
+        self.assertEqual(0, len(list(f1.generate("dogs"))))
+        self.assertEqual(1, len(list(f1.generate("octopus"))))
+        self.assertEqual(1, len(list(f1.generate("catdogs"))))
+        # * binds tighter than ~
+        f1 = FST.regex("~(cat | dog)*s")
+        self.assertEqual(0, len(list(f1.generate("catdogs"))))
+        self.assertEqual(0, len(list(f1.generate("catdogcats"))))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As mentioned in the documentation (https://github.com/mhulden/pyfoma/blob/main/docs/RegularExpressionCompiler.ipynb).  Implemented quite simply as `(.* - X)`

Fixes #27 