### PR TITLE
Add lexc-style multichar_symbols for `rlg`, `from_strings` and `regex`

### DIFF
--- a/src/pyfoma/algorithms.py
+++ b/src/pyfoma/algorithms.py
@@ -737,9 +737,9 @@ def difference(fst1: 'FST', fst2: 'FST') -> 'FST':
                        oplus = lambda x,y: x, pathfollow = lambda x,y: x)
 
 
-def complement(fsm: 'FST') -> 'FST':
-    """Returns the complement of an FSM."""
-    return FST.re(".* - $X", {"X": fsm})
+def complement(fst: 'FST') -> 'FST':
+    """Returns the complement of an FST."""
+    return FST.re(".* - $X", {"X": fst})
 
 
 @_harmonize_alphabet

--- a/src/pyfoma/fst.py
+++ b/src/pyfoma/fst.py
@@ -117,12 +117,12 @@ class FST:
 
     re = regex
 
-
     @classmethod
-    def from_strings(cls, strings):
+    def from_strings(cls, strings, multichar_symbols=None):
         """Create an automaton that accepts words in the iterable 'strings'."""
-        Grammar = {"Start":((w, "#") for w in strings)}
-        return FST.rlg(Grammar, "Start").determinize_as_dfa().minimize().label_states_topology()
+        Grammar = {"Start": ((w, "#") for w in strings)}
+        lex = FST.rlg(Grammar, "Start", multichar_symbols=multichar_symbols)
+        return lex.determinize_as_dfa().minimize().label_states_topology()
 
     @classmethod
     def rlg(cls, grammar, startsymbol, multichar_symbols=None):

--- a/test_pyfoma.py
+++ b/test_pyfoma.py
@@ -123,5 +123,30 @@ class TestFST(unittest.TestCase):
         self.assertEqual("cat", next(f1.generate("octopus")))
 
 
+class TestSymbols(unittest.TestCase):
+    MULTICHAR_SYMBOLS = "u: ch ll x̌ʷ".split()
+
+    def test_rlg_multichar(self):
+        """Verify multi-character symbols in lexicons (lexc style)"""
+        # Hopefully the third one is not an actual word for anyone
+        words = ["hecho", "llama", "xu:x̌ʷ"]
+        lex = FST.rlg({
+            "Root": [(word, "#") for word in words]
+        }, "Root", multichar_symbols=self.MULTICHAR_SYMBOLS)
+        for sym in self.MULTICHAR_SYMBOLS:
+            self.assertTrue(sym in lex.alphabet)
+        for word in words:
+            self.assertEqual(word, next(lex.generate(word)))
+
+    def test_rewrite_multichar(self):
+        """Verify multi-character symbols in rewrite rules"""
+        # Yes, you can put forbidden characters in symbols now (just
+        # because you can doesn't necessarily mean you should)
+        rule = FST.regex("$^rewrite(x̌ʷ:x / u: _ #)",
+                         multichar_symbols=self.MULTICHAR_SYMBOLS)
+        self.assertEqual("xu:x", next(rule.generate("xu:x̌ʷ")))
+        self.assertEqual("xux̌ʷ", next(rule.generate("xux̌ʷ")))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test_pyfoma.py
+++ b/test_pyfoma.py
@@ -138,6 +138,16 @@ class TestSymbols(unittest.TestCase):
         for word in words:
             self.assertEqual(word, next(lex.generate(word)))
 
+    def test_from_strings_multichar(self):
+        """Verify multi-character symbols in from_strings"""
+        # Hopefully the third one is not an actual word for anyone
+        words = ["hecho", "llama", "xu:x̌ʷ"]
+        lex = FST.from_strings(words, multichar_symbols=self.MULTICHAR_SYMBOLS)
+        for sym in self.MULTICHAR_SYMBOLS:
+            self.assertTrue(sym in lex.alphabet)
+        for word in words:
+            self.assertEqual(word, next(lex.generate(word)))
+
     def test_rewrite_multichar(self):
         """Verify multi-character symbols in rewrite rules"""
         # Yes, you can put forbidden characters in symbols now (just


### PR DESCRIPTION
As per suggestion in #30 this adds an optional `multichar_symbols` argument to the abovementioned methods, which works (mostly?) like `Multichar_Symbols` in lexc.

It also fixes a little problem in my previous PR for `complement` as I didn't realize that argument names for algorithms were significant... oops!  (still not sure if complement is really defined for transducers)