### PR TITLE
fix: ensure longest multichar symbols are matched first

### DIFF
--- a/src/pyfoma/fst.py
+++ b/src/pyfoma/fst.py
@@ -19,11 +19,11 @@ def re(*args, **kwargs):
 def _multichar_matcher(multichar_symbols: Iterable[str]) -> pyre.Pattern:
     """Create matcher for unquoted multichar symbols in lexicons and
     regular expressions."""
+    ordered = [sym for sym in multichar_symbols if len(sym) > 1]
+    ordered.sort(key=len, reverse=True)
     return pyre.compile(
         r"('(?:\\'|[^'])*')|("
-        + "|".join(pyre.escape(sym)
-                   for sym in multichar_symbols
-                   if len(sym) > 1)
+        + "|".join(pyre.escape(sym) for sym in ordered)
         + r")")
 
 

--- a/test_pyfoma.py
+++ b/test_pyfoma.py
@@ -203,6 +203,12 @@ class TestSymbols(unittest.TestCase):
         self.assertEqual("xu:x", next(rule.generate("xu:x̌ʷ")))
         self.assertEqual("xux̌ʷ", next(rule.generate("xux̌ʷ")))
 
+    def test_longest_match(self):
+        """Verify that longest multichar symbols are matched"""
+        rule = FST.regex("$^rewrite(ABC:D)",
+                         multichar_symbols=["A", "B", "C", "AB", "ABC"])
+        self.assertEqual("ABD", next(rule.generate("ABABC")))
+
 
 class TestUtil(unittest.TestCase):
     """Test utility functions."""


### PR DESCRIPTION
With the caveat that probably having multichar symbols that are prefixes of each other is not the greatest idea, the expected behaviour (by this user at least) is that they should function the same way in the grammar and regex compilers as they do in `tokenize_against_alphabet`, i.e. longest-leftmost matching.

Otherwise many subtle errors may appear, particularly since phonemic inventories have a tendency to be written like this:

    p t k pʰ tʰ kʰ
    a i u a: i: u:

...oops!