### PR TITLE
fix: correctly handle escaped quotes in multichar matcher

### DIFF
--- a/src/pyfoma/_private/regexparse.py
+++ b/src/pyfoma/_private/regexparse.py
@@ -328,7 +328,7 @@ def _multichar_matcher(multichar_symbols: Iterable[str]) -> pyre.Pattern:
     ordered = [sym for sym in multichar_symbols if len(sym) > 1]
     ordered.sort(key=len, reverse=True)
     return pyre.compile(
-        r"('(?:\\'|[^'])*')|("
+        r"(\\'|'(?:\\'|[^'])*')|("
         + "|".join(pyre.escape(sym) for sym in ordered)
         + r")")
 

--- a/tests/test_pyfoma.py
+++ b/tests/test_pyfoma.py
@@ -596,12 +596,18 @@ class TestSymbols(unittest.TestCase):
     def test_quotes(self):
         """Make sure already-quoted things stay quoted correctly and we
         can pathologically escape quotes everywhere"""
-        words = ["'HACKEM'MUCHE", r"FOOBIE'BL\'ETCH'", r"'''"]
-        lex = FST.from_strings(words, multichar_symbols=["CH", "BL"])
+        words = ["'HACKEM'MUCHE", r"FOOBIE'BL\'ETCH'", r"'''", r"EEP\'OOP\'"]
+        lex = FST.from_strings(words, multichar_symbols=["CH", "BL", "OO"])
         self.assertTrue("HACKEM" in lex.alphabet)
         self.assertTrue("BL'ETCH" in lex.alphabet)
         self.assertTrue("'" in lex.alphabet)
         self.assertTrue("CH" in lex.alphabet)
+        # Ensure that we handle escaped quotes correctly
+        self.assertEqual("EEP'OOP'", next(lex.generate("EEP'OOP'")))
+        self.assertEqual(lex.tokenize_against_alphabet("EEP'OOP'"),
+                         ['E', 'E', 'P', "'", 'OO', 'P', "'"])
+        self.assertTrue("OO" in lex.alphabet)
+        self.assertTrue("O" not in lex.alphabet)
         # Ensure that we don't introduce multichar_symbols inside
         # already quoted symbols
         self.assertTrue("BL" not in lex.alphabet)


### PR DESCRIPTION
As the saying goes, "You have a problem, you decide to use regular expressions, now you have two problems."

Despite my best efforts to test everything, I overlooked a corner case in the `multichar_symbols` code, which becomes immediately obvious when trying to use Pyfoma for Kwak'wala in U'mista orthography, for instance, which uses both Unicode grapheme clusters as well as single-quotes in great quantities.

Namely, the `_multichar_matcher` expression correctly doesn't escape multichars inside single quotes, *but* it also doesn't check to make sure these single quotes aren't backslash-escaped.

Until the next release one can work around this by escaping single-quotes in a very Microsoft-like way, as `'''`, but it would be better to be able to use backslashes, which this minor change (which recognizes and then escapes backslash-escaped quotes) will do.