### PR TITLE
Minor improvements to lexd compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ Demo
 # Cython
 *.c
 *.html
+*~

--- a/src/pyfoma/lexd.py
+++ b/src/pyfoma/lexd.py
@@ -121,6 +121,7 @@ def from_tuples(tuples_iter: Iterable[Iterable[Tuple[str, ...]]]) -> FST:
 @dataclass(frozen=True)
 class TagSelector:
     clauses: Tuple[Tuple[frozenset[str], frozenset[str]], ...]
+    raw: str | None = None
 
     @staticmethod
     def any() -> "TagSelector":
@@ -218,7 +219,7 @@ def parse_tag_selector(raw: str) -> TagSelector:
             comp_sel = TagSelector(((frozenset([comp]), frozenset()),))
         sel = sel.and_selector(comp_sel)
 
-    return sel
+    return TagSelector(sel.clauses, raw)
 
 # ----------------------------------------
 # Lexicon parsing helpers

--- a/src/pyfoma/lexd.py
+++ b/src/pyfoma/lexd.py
@@ -741,8 +741,8 @@ def _parse_token_ref(tok: str) -> TokRef:
 
     # Special lexd syntax: X(1):X(2) binds the same lexicon entry while using different columns
     # on the input/output side. (This is NOT the regex cross-product operator.)
-    if ":" in tok:
-        left, right = tok.split(":", 1)
+    left, colon, right = tok.partition(":")
+    if colon:
         m1 = re.match(r"^(.+?)\((\d+)\)$", left)
         m2 = re.match(r"^(.+?)\((\d+)\)$", right)
         if m1 and m2 and m1.group(1) == m2.group(1):
@@ -806,7 +806,7 @@ def _parse_pattern_expr(tokens: List[str], pos: int = 0) -> Tuple[PatExpr, int]:
 
             # Postfix selector(s) on the expression we just parsed: (...)[selector]
             while p < len(tokens) and tokens[p].startswith("__POSTSEL__:"):
-                raw = tokens[p].split(":", 1)[1]
+                raw = tokens[p][len("__POSTSEL__:"):]
                 sel = parse_tag_selector(raw.strip())
                 e = Tagged(e, sel)
                 p += 1
@@ -1071,7 +1071,7 @@ def parse_lexd(lexdstring: str) -> ParsedLexd:
                 continue
             if head == "LEXICON":
                 mode = "LEXICON"
-                rest_raw = line.split(None, 1)[1]
+                rest_raw = line.split()[1]
 
                 # Lexicon definition tags may appear as:
                 #   LEXICON A[x]
@@ -1198,9 +1198,8 @@ def _compile_lexicon_entry_variant(
         regex = _wrap_top_level_colon_operands(regex)
         return FST.re(regex)
 
-    if ":" in content:
-        lexside, surfside = content.split(":", 1)
-    else:
+    lexside, colon, surfside = content.partition(":")
+    if colon == "":
         lexside, surfside = content, content
     lexside = lexside.strip()
     surfside = surfside.strip()
@@ -1279,9 +1278,8 @@ def _compile_lexicon_variant(
             regex_union = rf if regex_union is None else union(regex_union, rf)
             continue
 
-        if ":" in content:
-            lexside, surfside = content.split(":", 1)
-        else:
+        lexside, colon, surfside = content.partition(":")
+        if colon == "":
             lexside, surfside = content, content
 
         lexside = lexside.strip()
@@ -1345,7 +1343,7 @@ def compile_lexd(parsed: ParsedLexd, strict_quoted: bool = False) -> FST:
         nonlocal anon_counter
 
         if tok.kind == "anonlex":
-            raw = tok.name.split(":", 1)[1]
+            _, _, raw = tok.name.partition(":")
             if tok.name not in anon_map:
                 anon_counter += 1
                 anon_name = f"__anonlex_{anon_counter}"


### PR DESCRIPTION
Wasn't able to make two separate PRs for this but it is two very small changes:

1. use `partition` instead of `split` to partition up/down sides of references
2. retain the string form of tag selectors for debugging/introspection purposes

### First change: use `partition`

It is slightly more efficient but also avoids confusing JavaScript programmers for whom the `limit` argument to String.prototype.split() does something subtly but frustratingly different.  More precisely:

- In Python, `maxsplit` is the number of *splits*, so "foo:bar:baz".split(":", 1) returns ["foo", "bar:baz"]
- In JavaScript, for ${reasons}, `limit` is the number of *outputs*, so "foo:bar:baz".split(":", 2) returns ["foo", "bar"]

This caused me some problems when porting the lexd compiler, so I figured it would be good to clarify the original code
(and it is, probably, a bit more efficient, though there are tons of other things that could be optimized)

### Second change: add string form of selectors

For various reasons, it may be useful to recover lexd code from a parsed definition. Generally this is straightforward, except in the case of tag selectors, which are not simply parsed but also pre-compiled in to a logical representation which has no direct expression in lexd syntax.

While it is possible to recover a textual form of valid selectors, it's not very fun to do, so it seems more useful to simply retain the original textual form in the parsed definition, which this patch does.

As an aside this pre-compilation creates a lot of redundancy in the case of overlapping selectors, for instance, `^[x,y],^[y,z]`, which actually means "x,z | y" (I think this has no representation in the weird lexd selector syntax?), but compiles to:

```
^[x,y],^[y,z]:
   must: ["x", "y"]
   mustnot: ["z", "y"]

   must: ["x", "z"]
   mustnot: ["y"]

   must: ["y"]
   mustnot: ["x", "z"]

   must: ["z", "y"]
   mustnot: ["x", "y"]
```

the first and last clauses are contradictory so can simply be dropped.  Which I could also add to this PR :grin: 